### PR TITLE
rmd-20676 Rename API wrapper authentication methods

### DIFF
--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeBeginPreScanTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeBeginPreScanTask.groovy
@@ -35,7 +35,7 @@ class VeracodeBeginPreScanTask extends VeracodeTask {
     }
 
     void run() {
-        writeXml('build/pre-scan.xml', loginUpdate().beginPreScan(project.appId))
+        writeXml('build/pre-scan.xml', uploadAPI().beginPreScan(project.appId))
         println 'Check build/pre-scan.xml for response status.'
     }
 }

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeBeginScanTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeBeginScanTask.groovy
@@ -48,6 +48,6 @@ class VeracodeBeginScanTask extends VeracodeTask {
             println 'WARNING: Not all the files in whitelist are being scanned. Some modules no longer exist? Manual whitelist maintenance should be performed.'
         }
 
-        writeXml('build/scan.xml', loginUpdate().beginScan(project.appId, moduleIds.join(","), 'false'))
+        writeXml('build/scan.xml', uploadAPI().beginScan(project.appId, moduleIds.join(","), 'false'))
     }
 }

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeCreateBuildTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeCreateBuildTask.groovy
@@ -37,7 +37,7 @@ class VeracodeCreateBuildTask extends VeracodeTask {
     void run() {
         Node buildInfo = writeXml(
                 'build/create-build.xml',
-                loginUpdate().createBuild(project.appId, project.buildName))
+                uploadAPI().createBuild(project.appId, project.buildName))
         if (buildInfo.name().equals('error')) {
             println buildInfo.text()
         } else {

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeCredentials.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeCredentials.groovy
@@ -27,7 +27,6 @@
 package com.calgaryscientific.gradle
 
 class VeracodeCredentials {
-    boolean apiCredentials
     String username
     String password
     String id

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeDeleteBuildTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeDeleteBuildTask.groovy
@@ -35,6 +35,6 @@ class VeracodeDeleteBuildTask extends VeracodeTask {
     }
 
     void run() {
-        writeXml('build/delete-build.xml', loginUpdate().deleteBuild(project.appId))
+        writeXml('build/delete-build.xml', uploadAPI().deleteBuild(project.appId))
     }
 }

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeDetailedReportTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeDetailedReportTask.groovy
@@ -35,7 +35,7 @@ class VeracodeDetailedReportTask extends VeracodeTask {
     }
 
     void run() {
-        String xmlResponse = loginResults().detailedReport(project.buildId)
+        String xmlResponse = resultsAPI().detailedReport(project.buildId)
         writeXml('build/scan-results.xml', xmlResponse)
     }
 }

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetAppInfoTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetAppInfoTask.groovy
@@ -35,7 +35,7 @@ class VeracodeGetAppInfoTask extends VeracodeTask {
     }
 
     void run() {
-        writeXml('build/app-info.xml', loginUpdate().getAppInfo(project.appId)
+        writeXml('build/app-info.xml', uploadAPI().getAppInfo(project.appId)
         ).application[0].attributes().each() { k, v ->
             println "$k=$v"
         }

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetAppListTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetAppListTask.groovy
@@ -34,7 +34,7 @@ class VeracodeGetAppListTask extends VeracodeTask {
     }
 
     void run() {
-        writeXml('build/app-list.xml', loginUpdate().getAppList())
+        writeXml('build/app-list.xml', uploadAPI().getAppList())
                 .each() { app ->
             println app.@app_id + '=' + app.@app_name
         }

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetBuildInfoTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetBuildInfoTask.groovy
@@ -37,9 +37,9 @@ class VeracodeGetBuildInfoTask extends VeracodeTask {
     void run() {
         String xmlResponse
         if (project.hasProperty('buildId')) {
-            xmlResponse = loginUpdate().getBuildInfo(project.appId, project.buildId)
+            xmlResponse = uploadAPI().getBuildInfo(project.appId, project.buildId)
         } else {
-            xmlResponse = loginUpdate().getBuildInfo(project.appId)
+            xmlResponse = uploadAPI().getBuildInfo(project.appId)
         }
         Node buildInfo = writeXml('build/build-info.xml', xmlResponse) // need to print twice, so assign var
         println '[Build]'

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetBuildListTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetBuildListTask.groovy
@@ -35,7 +35,7 @@ class VeracodeGetBuildListTask extends VeracodeTask {
     }
 
     void run() {
-        writeXml('build/build-list.xml', loginUpdate().getBuildList(project.appId)
+        writeXml('build/build-list.xml', uploadAPI().getBuildList(project.appId)
         ).each() { build ->
             println "${build.@build_id}=${build.@version}"
         }

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetFileListTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetFileListTask.groovy
@@ -37,9 +37,9 @@ class VeracodeGetFileListTask extends VeracodeTask {
     void run() {
         String xmlResponse
         if (project.hasProperty('buildId')) {
-            xmlResponse = loginUpdate().getFileList(project.appId, project.buildId)
+            xmlResponse = uploadAPI().getFileList(project.appId, project.buildId)
         } else {
-            xmlResponse = loginUpdate().getFileList(project.appId)
+            xmlResponse = uploadAPI().getFileList(project.appId)
         }
         Node filelist = writeXml('build/file-list.xml', xmlResponse)
         filelist.each() { file ->

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetPreScanResultsTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetPreScanResultsTask.groovy
@@ -37,9 +37,9 @@ class VeracodeGetPreScanResultsTask extends VeracodeTask {
     void run() {
         String xmlResponse
         if (project.hasProperty('buildId')) {
-            xmlResponse = loginUpdate().getPreScanResults(project.appId, project.buildId)
+            xmlResponse = uploadAPI().getPreScanResults(project.appId, project.buildId)
         } else {
-            xmlResponse = loginUpdate().getPreScanResults(project.appId)
+            xmlResponse = uploadAPI().getPreScanResults(project.appId)
         }
 
         Node result = writeXml('build/pre-scan-results.xml', xmlResponse)

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeRemoveFileTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeRemoveFileTask.groovy
@@ -35,6 +35,6 @@ class VeracodeRemoveFileTask extends VeracodeTask {
     }
 
     void run() {
-        writeXml('build/remove-file.xml', loginUpdate().removeFile(project.appId, project.fileId))
+        writeXml('build/remove-file.xml', uploadAPI().removeFile(project.appId, project.fileId))
     }
 }

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeTask.groovy
@@ -94,22 +94,32 @@ abstract class VeracodeTask extends DefaultTask {
         arg.endsWith(OPTIONAL)
     }
 
-    protected UploadAPIWrapper loginUpdate() {
+    protected boolean useAPICredentials() {
+        VeracodeCredentials vc = project.findProperty("veracodeCredentials") as VeracodeCredentials
+        if (vc.username != "" && vc.password != "") {
+            return false
+        }
+        return true
+    }
+
+    protected UploadAPIWrapper uploadAPI() {
         UploadAPIWrapper api = new UploadAPIWrapper()
-        if (project.veracodeCredentials.apiCredentials) {
-            api.setUpApiCredentials(project.veracodeCredentials.id, project.veracodeCredentials.key)
+        VeracodeCredentials vc = project.findProperty("veracodeCredentials") as VeracodeCredentials
+        if (useAPICredentials()) {
+            api.setUpApiCredentials(vc.id, vc.key)
         } else {
-            api.setUpCredentials(project.veracodeCredentials.username, project.veracodeCredentials.password)
+            api.setUpCredentials(vc.username, vc.password)
         }
         return api
     }
 
-    protected ResultsAPIWrapper loginResults() {
+    protected ResultsAPIWrapper resultsAPI() {
         ResultsAPIWrapper api = new ResultsAPIWrapper()
-        if (project.veracodeCredentials.apiCredentials) {
-            api.setUpApiCredentials(project.veracodeCredentials.id, project.veracodeCredentials.key)
+        VeracodeCredentials vc = project.findProperty("veracodeCredentials") as VeracodeCredentials
+        if (useAPICredentials()) {
+            api.setUpApiCredentials(vc.id, vc.key)
         } else {
-            api.setUpCredentials(project.veracodeCredentials.username, project.veracodeCredentials.password)
+            api.setUpCredentials(vc.username, vc.password)
         }
         return api
     }

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeUploadFileTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeUploadFileTask.groovy
@@ -39,7 +39,7 @@ class VeracodeUploadFileTask extends VeracodeTask {
 
     void run() {
         String xmlResponse = ''
-        UploadAPIWrapper update = loginUpdate()
+        UploadAPIWrapper update = uploadAPI()
         File uploadFolder = new File('build/to-upload')
         def error
         def tries = 1;

--- a/src/test/groovy/com/calgaryscientific/gradle/VeracodeTaskTest.groovy
+++ b/src/test/groovy/com/calgaryscientific/gradle/VeracodeTaskTest.groovy
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * MIT License
+ *
+ * Copyright (c) 2017 Calgary Scientific Incorporated
+ *
+ * Copyright (c) 2013-2014 kctang
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+
+package com.calgaryscientific.gradle
+
+import spock.lang.Specification
+import org.gradle.testkit.runner.GradleRunner
+import static org.gradle.testkit.runner.TaskOutcome.*
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+
+class VeracodeTaskTest extends Specification {
+    @Rule
+    final TemporaryFolder testProjectDir = new TemporaryFolder()
+    File buildFile
+    Boolean debug = true
+
+    def setup() {
+        buildFile = testProjectDir.newFile('build.gradle')
+    }
+
+    def GradleBuild(String... tasks) {
+        GradleRunner.create()
+                .withDebug(debug)
+                .withProjectDir(testProjectDir.root)
+                .withPluginClasspath()
+                .withArguments(tasks)
+                .build()
+    }
+
+    def 'Test veracodeCredentials usage'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.calgaryscientific.gradle.veracode'
+            }
+
+            veracodeSetup {
+                username = 'user'
+                password = 'pass'
+                id = 'id'
+                key = 'key'
+            }
+            task verify {
+                doLast {
+                    assert project.veracodeSetup.username == 'user'
+                    assert project.veracodeSetup.password == 'pass'
+                    assert project.veracodeSetup.id == 'id'
+                    assert project.veracodeSetup.key == 'key'
+                    def vc = project.findProperty('veracodeSetup')
+                    assert vc.key == 'key'
+                }
+            }
+        """
+
+        when:
+        def result = GradleBuild('verify')
+
+        then:
+        result.task(":verify").outcome == SUCCESS
+    }
+}


### PR DESCRIPTION
These methods return an API object, rename them to better reflect that.

* Rename loginUpdate to uploadAPI
* Rename loginResults to resultsAPI

Also, prefer authentication of username and password when available and
remove need for VeracodeCredentials.apiCredentials field.

@tonytvo @mch please review.