### PR TITLE
rmd-20676 Rename attribute and keys identifiers to match Veracode API

### DIFF
--- a/src/main/groovy/com/calgaryscientific/gradle/PreScanModuleVerifyTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/PreScanModuleVerifyTask.groovy
@@ -31,17 +31,17 @@ class PreScanModuleVerifyTask extends VeracodeTask {
 
     PreScanModuleVerifyTask() {
         description = 'Verifies that all jars uploaded to Veracode are categorized in the blacklists/whitelist'
-        requiredArguments << 'appId'
+        requiredArguments << 'app_id'
     }
 
     void run() {
         println "Verifying against modules list modules-*.txt..."
         println ""
 
-        def blackListErr = readListFromFile(new File("src/apps/${project.appId}/modules-blacklist-error.txt"))
-        def blackListExt = readListFromFile(new File("src/apps/${project.appId}/modules-blacklist-external.txt"))
-        def blackListInt = readListFromFile(new File("src/apps/${project.appId}/modules-blacklist-internal.txt"))
-        def whiteList = readListFromFile(new File("src/apps/${project.appId}/modules-whitelist.txt"))
+        def blackListErr = readListFromFile(new File("src/apps/${project.app_id}/modules-blacklist-error.txt"))
+        def blackListExt = readListFromFile(new File("src/apps/${project.app_id}/modules-blacklist-external.txt"))
+        def blackListInt = readListFromFile(new File("src/apps/${project.app_id}/modules-blacklist-internal.txt"))
+        def whiteList = readListFromFile(new File("src/apps/${project.app_id}/modules-whitelist.txt"))
 
         def allList = blackListErr + blackListExt + blackListInt + whiteList
         allList = allList.sort()

--- a/src/main/groovy/com/calgaryscientific/gradle/ReportFlawsByTeamTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/ReportFlawsByTeamTask.groovy
@@ -34,11 +34,11 @@ class ReportFlawsByTeamTask extends VeracodeTask {
 
     ReportFlawsByTeamTask() {
         description = 'Creates a report for flaws categorized to teams'
-        requiredArguments << 'appId' << 'mode'
+        requiredArguments << 'app_id' << 'mode'
     }
 
     void run() {
-        def teams = new JsonSlurper().parse(new FileReader("src/apps/${project.appId}/teams.json")).teams
+        def teams = new JsonSlurper().parse(new FileReader("src/apps/${project.app_id}/teams.json")).teams
         int count = 0
 
         readXml('build/scan-results.xml').severity.each() { severity ->

--- a/src/main/groovy/com/calgaryscientific/gradle/ReportFlawsDiffTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/ReportFlawsDiffTask.groovy
@@ -31,11 +31,11 @@ class ReportFlawsDiffTask extends VeracodeTask {
 
     ReportFlawsDiffTask() {
         description = 'Compares veracode report for two builds'
-        requiredArguments << 'buildId1' << 'buildId2'
+        requiredArguments << 'build_id1' << 'build_id2'
     }
 
     void run() {
-        println 'Can you help to implement this? Basically, performing veracodeScanResults on two buildIds and report on:'
+        println 'Can you help to implement this? Basically, performing veracodeScanResults on two build_ids and report on:'
         println '  - Flaws in build1 only.'
         println '  - Flaws in build2 only.'
         println '  - Flaws where status changed from build1 to build2.'

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeBeginPreScanTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeBeginPreScanTask.groovy
@@ -31,11 +31,11 @@ class VeracodeBeginPreScanTask extends VeracodeTask {
 
     VeracodeBeginPreScanTask() {
         description = 'Start Veracode pre-scan for the application id passed in'
-        requiredArguments << 'appId'
+        requiredArguments << 'app_id'
     }
 
     void run() {
-        writeXml('build/pre-scan.xml', uploadAPI().beginPreScan(project.appId))
+        writeXml('build/pre-scan.xml', uploadAPI().beginPreScan(project.app_id))
         println 'Check build/pre-scan.xml for response status.'
     }
 }

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeBeginScanTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeBeginScanTask.groovy
@@ -31,12 +31,12 @@ class VeracodeBeginScanTask extends VeracodeTask {
 
     VeracodeBeginScanTask() {
         description = 'Starts a Veracode scan for the application id passed in'
-        requiredArguments << 'appId'
+        requiredArguments << 'app_id'
     }
 
     void run() {
         def moduleIds = []
-        def whiteList = readListFromFile(new File("src/apps/${project.appId}/modules-whitelist.txt"))
+        def whiteList = readListFromFile(new File("src/apps/${project.app_id}/modules-whitelist.txt"))
         readXml('build/pre-scan-results.xml').each() { module ->
             if (whiteList.contains(module.@name)) {
                 moduleIds << module.@id
@@ -48,6 +48,6 @@ class VeracodeBeginScanTask extends VeracodeTask {
             println 'WARNING: Not all the files in whitelist are being scanned. Some modules no longer exist? Manual whitelist maintenance should be performed.'
         }
 
-        writeXml('build/scan.xml', uploadAPI().beginScan(project.appId, moduleIds.join(","), 'false'))
+        writeXml('build/scan.xml', uploadAPI().beginScan(project.app_id, moduleIds.join(","), 'false'))
     }
 }

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeCreateBuildTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeCreateBuildTask.groovy
@@ -30,14 +30,14 @@ class VeracodeCreateBuildTask extends VeracodeTask {
     static final String NAME = 'veracodeCreateBuild'
 
     VeracodeCreateBuildTask() {
-        description = 'Creates a new build under the application id passed in, with the buildName as the identifier for the new build'
-        requiredArguments << 'appId' << 'buildName'
+        description = 'Creates a new build under the application id passed in, with the build_version as the identifier for the new build'
+        requiredArguments << 'app_id' << 'build_version'
     }
 
     void run() {
         Node buildInfo = writeXml(
                 'build/create-build.xml',
-                uploadAPI().createBuild(project.appId, project.buildName))
+                uploadAPI().createBuild(project.app_id, project.build_version))
         if (buildInfo.name().equals('error')) {
             println buildInfo.text()
         } else {

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeDeleteBuildTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeDeleteBuildTask.groovy
@@ -31,10 +31,10 @@ class VeracodeDeleteBuildTask extends VeracodeTask {
 
     VeracodeDeleteBuildTask() {
         description = 'Deletes the most recent build, even those that have their scan completed!'
-        requiredArguments << 'appId'
+        requiredArguments << 'app_id'
     }
 
     void run() {
-        writeXml('build/delete-build.xml', uploadAPI().deleteBuild(project.appId))
+        writeXml('build/delete-build.xml', uploadAPI().deleteBuild(project.app_id))
     }
 }

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeDetailedReportTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeDetailedReportTask.groovy
@@ -31,11 +31,11 @@ class VeracodeDetailedReportTask extends VeracodeTask {
 
     VeracodeDetailedReportTask() {
         description = 'Gets the Veracode scan results based on the build id passed in'
-        requiredArguments << 'buildId'
+        requiredArguments << 'build_id'
     }
 
     void run() {
-        String xmlResponse = resultsAPI().detailedReport(project.buildId)
+        String xmlResponse = resultsAPI().detailedReport(project.build_id)
         writeXml('build/scan-results.xml', xmlResponse)
     }
 }

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetAppInfoTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetAppInfoTask.groovy
@@ -31,11 +31,11 @@ class VeracodeGetAppInfoTask extends VeracodeTask {
 
     VeracodeGetAppInfoTask() {
         description = 'Lists application information based on the application id passed in'
-        requiredArguments << 'appId'
+        requiredArguments << 'app_id'
     }
 
     void run() {
-        writeXml('build/app-info.xml', uploadAPI().getAppInfo(project.appId)
+        writeXml('build/app-info.xml', uploadAPI().getAppInfo(project.app_id)
         ).application[0].attributes().each() { k, v ->
             println "$k=$v"
         }

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetBuildInfoTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetBuildInfoTask.groovy
@@ -31,16 +31,16 @@ class VeracodeGetBuildInfoTask extends VeracodeTask {
 
     VeracodeGetBuildInfoTask() {
         description = "Lists latest build information for the applicaiton id passed in. If a build id is provided, that build's information will be listed instead"
-        requiredArguments << 'appId'
-        optionalArguments << 'buildId'
+        requiredArguments << 'app_id'
+        optionalArguments << 'build_id'
     }
 
     void run() {
         String xmlResponse
-        if (project.hasProperty('buildId')) {
-            xmlResponse = uploadAPI().getBuildInfo(project.appId, project.buildId)
+        if (project.hasProperty('build_id')) {
+            xmlResponse = uploadAPI().getBuildInfo(project.app_id, project.build_id)
         } else {
-            xmlResponse = uploadAPI().getBuildInfo(project.appId)
+            xmlResponse = uploadAPI().getBuildInfo(project.app_id)
         }
         Node buildInfo = writeXml('build/build-info.xml', xmlResponse) // need to print twice, so assign var
         println '[Build]'

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetBuildListTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetBuildListTask.groovy
@@ -31,11 +31,11 @@ class VeracodeGetBuildListTask extends VeracodeTask {
 
     VeracodeGetBuildListTask() {
         description = 'Lists builds that are under the apllication id passed in'
-        requiredArguments << 'appId'
+        requiredArguments << 'app_id'
     }
 
     void run() {
-        writeXml('build/build-list.xml', uploadAPI().getBuildList(project.appId)
+        writeXml('build/build-list.xml', uploadAPI().getBuildList(project.app_id)
         ).each() { build ->
             println "${build.@build_id}=${build.@version}"
         }

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetFileListTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetFileListTask.groovy
@@ -31,16 +31,16 @@ class VeracodeGetFileListTask extends VeracodeTask {
 
     VeracodeGetFileListTask() {
         description = "Lists all files under the latest build for the application id passed in. If a build id is provided, the files under that build will be listed instead"
-        requiredArguments << 'appId'
-        optionalArguments << 'buildId'
+        requiredArguments << 'app_id'
+        optionalArguments << 'build_id'
     }
 
     void run() {
         String xmlResponse
-        if (project.hasProperty('buildId')) {
-            xmlResponse = uploadAPI().getFileList(project.appId, project.buildId)
+        if (project.hasProperty('build_id')) {
+            xmlResponse = uploadAPI().getFileList(project.app_id, project.build_id)
         } else {
-            xmlResponse = uploadAPI().getFileList(project.appId)
+            xmlResponse = uploadAPI().getFileList(project.app_id)
         }
         Node filelist = writeXml('build/file-list.xml', xmlResponse)
         filelist.each() { file ->

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetPreScanResultsTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeGetPreScanResultsTask.groovy
@@ -31,16 +31,16 @@ class VeracodeGetPreScanResultsTask extends VeracodeTask {
 
     VeracodeGetPreScanResultsTask() {
         description = 'Gets the results for Veracode pre-scan for the application id passed in'
-        requiredArguments << 'appId'
-        optionalArguments << 'buildId'
+        requiredArguments << 'app_id'
+        optionalArguments << 'build_id'
     }
 
     void run() {
         String xmlResponse
-        if (project.hasProperty('buildId')) {
-            xmlResponse = uploadAPI().getPreScanResults(project.appId, project.buildId)
+        if (project.hasProperty('build_id')) {
+            xmlResponse = uploadAPI().getPreScanResults(project.app_id, project.build_id)
         } else {
-            xmlResponse = uploadAPI().getPreScanResults(project.appId)
+            xmlResponse = uploadAPI().getPreScanResults(project.app_id)
         }
 
         Node result = writeXml('build/pre-scan-results.xml', xmlResponse)

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeRemoveFileTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeRemoveFileTask.groovy
@@ -31,10 +31,10 @@ class VeracodeRemoveFileTask extends VeracodeTask {
 
     VeracodeRemoveFileTask() {
         description = 'Remove file based on the file id for the application id passed in'
-        requiredArguments << 'appId' << 'fileId'
+        requiredArguments << 'app_id' << 'file_id'
     }
 
     void run() {
-        writeXml('build/remove-file.xml', uploadAPI().removeFile(project.appId, project.fileId))
+        writeXml('build/remove-file.xml', uploadAPI().removeFile(project.app_id, project.file_id))
     }
 }

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeTask.groovy
@@ -36,16 +36,16 @@ import com.veracode.apiwrapper.wrappers.ResultsAPIWrapper
 abstract class VeracodeTask extends DefaultTask {
     abstract static final String NAME
     final static def validArguments = [
-            'appId'            : '123',
-            'buildId'          : '123',
-            'buildName'        : 'xxx',
+            'app_id'           : '123',
+            'build_id'         : '123',
+            'build_version'    : 'xxx',
             'dir'              : 'xxx',
             'force'            : 'force',
-            'fileId'           : '123',
+            'file_id'          : '123',
             'mode'             : 'action|actionSummary|verbose',
             'maxUploadAttempts': '123',
-            'buildId1'         : '123',
-            'buildId2'         : '123'
+            'build_id1'        : '123',
+            'build_id2'        : '123'
     ]
 
     List<String> requiredArguments = []

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeUploadFileTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeUploadFileTask.groovy
@@ -34,7 +34,7 @@ class VeracodeUploadFileTask extends VeracodeTask {
 
     VeracodeUploadFileTask() {
         description = "Uploads all files from 'build/to-upload' folder to Veracode based on the application id provided"
-        requiredArguments << 'appId'
+        requiredArguments << 'app_id'
         optionalArguments << 'maxUploadAttempts'
     }
 
@@ -60,7 +60,7 @@ class VeracodeUploadFileTask extends VeracodeTask {
             // upload each file in build/to-upload
             for (File file : fileList) {
                 try {
-                    xmlResponse = update.uploadFile(project.appId, file.absolutePath)
+                    xmlResponse = update.uploadFile(project.app_id, file.absolutePath)
                     project.delete file.absolutePath
                     println "Processed $file.name"
                 } catch (Exception e) {

--- a/src/test/groovy/com/calgaryscientific/gradle/VeracodeTaskTest.groovy
+++ b/src/test/groovy/com/calgaryscientific/gradle/VeracodeTaskTest.groovy
@@ -72,12 +72,12 @@ class VeracodeTaskTest extends Specification {
 
     def 'Test error message on missing parameters'() {
         when:
-        List<String> requiredArgs = ["appId"]
-        List<String> optionalArgs = ["buildId"]
+        List<String> requiredArgs = ["app_id"]
+        List<String> optionalArgs = ["build_id"]
         String correctUsage = VeracodeTask.correctUsage('VeracodeGetBuildList', requiredArgs, optionalArgs)
 
         then:
-        correctUsage == "Missing required arguments: gradle VeracodeGetBuildList -PappId=123 [-PbuildId=123]"
+        correctUsage == "Missing required arguments: gradle VeracodeGetBuildList -Papp_id=123 [-Pbuild_id=123]"
     }
 
     def 'Test veracodeCredentials usage'() {


### PR DESCRIPTION
The Veracode API returns results using snake_case.
Change key and attribute identifies to match that to make way for moving
into static compilation.

appId -> app_id
buildId -> build_id
buildName -> build_version
fileId -> file_id

@tonytvo please review.