### PR TITLE
rmd-23648 Bump version to 0.6.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -39,7 +39,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'gradle.plugin.com.calgaryscientific.gradle:veracodePlugin:0.5.0'
+        classpath 'gradle.plugin.com.calgaryscientific.gradle:veracodePlugin:0.6.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'java-gradle-plugin'
 apply plugin: 'com.gradle.plugin-publish'
 
 group = 'com.calgaryscientific.gradle'
-version = '0.5.0'
+version = '0.6.0'
 sourceCompatibility = 1.7
 
 dependencies {


### PR DESCRIPTION
* Stop using global properties to configure the plugin and fully use the
veracodeSetup extension instead.

* Retrieve flaw report summary in workflow tasks and add option to fail
the build if there are new flaws introduced.