### PR TITLE
Add autoscan option

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -107,6 +107,7 @@ String file_id
 
 // Upload Config
 Boolean deleteUploadedArtifacts = false
+Boolean autoscan = false
 Integer maxUploadAttempts = 10
 Integer waitTimeBetweenAttempts = 5000
 Set<File> filesToUpload

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeAPI.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeAPI.groovy
@@ -49,8 +49,16 @@ class VeracodeAPI {
         return veracodeAPIFactory.uploadAPI().beginPreScan(app_id)
     }
 
+    String beginPreScan(Boolean autoscan) {
+        return veracodeAPIFactory.uploadAPI().beginPreScan(app_id, null, autoscan.toString())
+    }
+
     String beginPreScanSandbox() {
         return veracodeAPIFactory.uploadAPI().beginPreScan(app_id, sandbox_id)
+    }
+
+    String beginPreScanSandbox(Boolean autoscan) {
+        return veracodeAPIFactory.uploadAPI().beginPreScan(app_id, sandbox_id, autoscan.toString())
     }
 
     String beginScan(Set<String> moduleIds) {

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeSetup.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeSetup.groovy
@@ -61,6 +61,7 @@ class VeracodeSetup {
     Integer waitTimeBetweenAttempts = 5000
     Set<File> filesToUpload
     Set<File> sandboxFilesToUpload
+    Boolean autoscan = false
 
     // Scan Config
     Set<String> moduleWhitelist

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeWorkflow.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeWorkflow.groovy
@@ -44,7 +44,8 @@ class VeracodeWorkflow {
                             Integer maxTries,
                             Integer waitTime,
                             Boolean delete,
-                            Boolean failOnNewFlaws
+                            Boolean failOnNewFlaws,
+                            Boolean autoscan
     ) {
         // Work on the latest build
         String build_id = null
@@ -93,7 +94,7 @@ class VeracodeWorkflow {
             log.info("uploadFile: " + fileSet)
             VeracodeUploadFile.uploadFiles(veracodeAPI, VeracodeFileList.getFile(outputDir, app_id, build_id), fileSet, maxTries, waitTime, delete)
             log.info("beginPreScan")
-            buildInfo = XMLIO.writeXmlWithErrorCheck(VeracodeBuildInfo.getFile(outputDir, app_id, build_id), veracodeAPI.beginPreScan())
+            buildInfo = XMLIO.writeXmlWithErrorCheck(VeracodeBuildInfo.getFile(outputDir, app_id, build_id), veracodeAPI.beginPreScan(autoscan))
             buildStatus = VeracodeBuildInfo.getBuildStatus(buildInfo)
             log.info("buildStatus: " + buildStatus)
         }
@@ -125,7 +126,8 @@ class VeracodeWorkflow {
                                 Integer maxTries,
                                 Integer waitTime,
                                 Boolean delete,
-                                Boolean failOnNewFlaws
+                                Boolean failOnNewFlaws,
+                                Boolean autoscan
     ) {
         // Work on the latest build
         String build_id = null
@@ -174,7 +176,7 @@ class VeracodeWorkflow {
             log.info("uploadFile: " + fileSet)
             VeracodeUploadFile.uploadSandboxFiles(veracodeAPI, VeracodeFileList.getSandboxFile(outputDir, app_id, sandbox_id, build_id), fileSet, maxTries, waitTime, delete)
             log.info("beginPreScan")
-            buildInfo = XMLIO.writeXmlWithErrorCheck(VeracodeBuildInfo.getSandboxFile(outputDir, app_id, sandbox_id, build_id), veracodeAPI.beginPreScanSandbox())
+            buildInfo = XMLIO.writeXmlWithErrorCheck(VeracodeBuildInfo.getSandboxFile(outputDir, app_id, sandbox_id, build_id), veracodeAPI.beginPreScanSandbox(autoscan))
             buildStatus = VeracodeBuildInfo.getBuildStatus(buildInfo)
             log.info("buildStatus: " + buildStatus)
         }

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeWorkflowSandboxTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeWorkflowSandboxTask.groovy
@@ -36,7 +36,7 @@ class VeracodeWorkflowSandboxTask extends VeracodeTask {
         group = 'Veracode Sandbox'
         description = "Run through the Veracode Workflow for the given 'app_id' and 'sandbox_id' using 'build_version' as the build identifier"
         requiredArguments << 'app_id' << 'sandbox_id' << 'build_version'
-        optionalArguments << 'maxUploadAttempts' << 'waitTimeBetweenAttempts' << 'delete' << 'ignoreFailure'
+        optionalArguments << 'maxUploadAttempts' << 'waitTimeBetweenAttempts' << 'delete' << 'ignoreFailure' << 'autoscan'
     }
 
     Set<File> getFileSet() {
@@ -60,7 +60,8 @@ class VeracodeWorkflowSandboxTask extends VeracodeTask {
                     veracodeSetup.maxUploadAttempts,
                     veracodeSetup.waitTimeBetweenAttempts,
                     veracodeSetup.deleteUploadedArtifacts,
-                    veracodeSetup.failWorkflowTasksOnNewFlaws
+                    veracodeSetup.failWorkflowTasksOnNewFlaws,
+                    veracodeSetup.autoscan
             )
         } catch (Exception e) {
             if (veracodeSetup.ignoreFailure) {

--- a/src/main/groovy/com/calgaryscientific/gradle/VeracodeWorkflowTask.groovy
+++ b/src/main/groovy/com/calgaryscientific/gradle/VeracodeWorkflowTask.groovy
@@ -35,7 +35,7 @@ class VeracodeWorkflowTask extends VeracodeTask {
     VeracodeWorkflowTask() {
         description = "Run through the Veracode Workflow for the given 'app_id' using 'build_version' as the build identifier"
         requiredArguments << 'app_id' << 'build_version'
-        optionalArguments << 'maxUploadAttempts' << 'waitTimeBetweenAttempts' << 'deleteUploadedArtifacts' << 'ignoreFailure'
+        optionalArguments << 'maxUploadAttempts' << 'waitTimeBetweenAttempts' << 'deleteUploadedArtifacts' << 'ignoreFailure' << 'autoscan'
     }
 
     Set<File> getFileSet() {
@@ -57,7 +57,8 @@ class VeracodeWorkflowTask extends VeracodeTask {
                     veracodeSetup.maxUploadAttempts,
                     veracodeSetup.waitTimeBetweenAttempts,
                     veracodeSetup.deleteUploadedArtifacts,
-                    veracodeSetup.failWorkflowTasksOnNewFlaws
+                    veracodeSetup.failWorkflowTasksOnNewFlaws,
+                    veracodeSetup.autoscan
             )
         } catch (Exception e) {
             if (veracodeSetup.ignoreFailure) {

--- a/src/test/groovy/com/calgaryscientific/gradle/VeracodeWorkflowDOTest.groovy
+++ b/src/test/groovy/com/calgaryscientific/gradle/VeracodeWorkflowDOTest.groovy
@@ -55,6 +55,7 @@ class VeracodeWorkflowDOTest extends TestCommonSetup {
         Set<String> moduleWhitelist = ['class1.jar', 'class2.jar', 'class3.jar']
         Boolean delete = false
         Boolean failOnNewFlaws = false
+        Boolean autoscan = false
         VeracodeAPI veracodeAPIMock = Mock(VeracodeAPI, constructorArgs: [null, null, null])
 
         when:
@@ -67,7 +68,8 @@ class VeracodeWorkflowDOTest extends TestCommonSetup {
                 maxUploadAttempts,
                 waitTimeBetweenAttempts,
                 delete,
-                failOnNewFlaws
+                failOnNewFlaws,
+                autoscan
         )
 
         then:
@@ -96,7 +98,7 @@ class VeracodeWorkflowDOTest extends TestCommonSetup {
         }
 
         then:
-        1 * veracodeAPIMock.beginPreScan() >> {
+        1 * veracodeAPIMock.beginPreScan(false) >> {
             // status=Submitted to Engine
             return new String(buildInfoFile.readBytes())
         }
@@ -113,6 +115,7 @@ class VeracodeWorkflowDOTest extends TestCommonSetup {
         Set<String> moduleWhitelist = ['class1.jar', 'class2.jar', 'class3.jar']
         Boolean delete = false
         Boolean failOnNewFlaws = false
+        Boolean autoscan = false
         VeracodeAPI veracodeAPIMock = Mock(VeracodeAPI, constructorArgs: [null, null, null])
 
         when:
@@ -125,7 +128,8 @@ class VeracodeWorkflowDOTest extends TestCommonSetup {
                 maxUploadAttempts,
                 waitTimeBetweenAttempts,
                 delete,
-                failOnNewFlaws
+                failOnNewFlaws,
+                autoscan
         )
 
         then:
@@ -156,6 +160,7 @@ class VeracodeWorkflowDOTest extends TestCommonSetup {
         Set<String> moduleWhitelist = ['class1.jar', 'class2.jar', 'class3.jar']
         Boolean delete = false
         Boolean failOnNewFlaws = false
+        Boolean autoscan = false
         VeracodeAPI veracodeAPIMock = Mock(VeracodeAPI, constructorArgs: [null, null, null])
 
         when:
@@ -169,7 +174,8 @@ class VeracodeWorkflowDOTest extends TestCommonSetup {
                 maxUploadAttempts,
                 waitTimeBetweenAttempts,
                 delete,
-                failOnNewFlaws
+                failOnNewFlaws,
+                autoscan
         )
 
         then:
@@ -198,7 +204,7 @@ class VeracodeWorkflowDOTest extends TestCommonSetup {
         }
 
         then:
-        1 * veracodeAPIMock.beginPreScanSandbox() >> {
+        1 * veracodeAPIMock.beginPreScanSandbox(false) >> {
             // status=Submitted to Engine
             return new String(buildInfoFile.readBytes())
         }
@@ -216,6 +222,7 @@ class VeracodeWorkflowDOTest extends TestCommonSetup {
         Set<String> moduleWhitelist = ['class1.jar', 'class2.jar', 'class3.jar']
         Boolean delete = false
         Boolean failOnNewFlaws = false
+        Boolean autoscan = false
         VeracodeAPI veracodeAPIMock = Mock(VeracodeAPI, constructorArgs: [null, null, null])
 
         when:
@@ -229,7 +236,8 @@ class VeracodeWorkflowDOTest extends TestCommonSetup {
                 maxUploadAttempts,
                 waitTimeBetweenAttempts,
                 delete,
-                failOnNewFlaws
+                failOnNewFlaws,
+                autoscan
         )
 
         then:


### PR DESCRIPTION
Hi there,

We use Veracode to scan our Java applications for vulnerabilities. This plugin has been absolutely fantastic in integrating into our CICD pipeline. What we were hoping for, however, was an autoscan option. This PR adds support for turning the "Autoscan after prescan" on.